### PR TITLE
Post-build Docker Resources Cleanup & Resource Namespacing for Build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,6 @@
 set -e
 
 export DEFCONFIG=docker_rpi3_defconfig
-docker-compose build
-docker-compose run builder
-docker-compose down
+docker-compose -p rpikernelbuild build
+docker-compose -p rpikernelbuild run builder
+docker-compose -p rpikernelbuild down

--- a/build.sh
+++ b/build.sh
@@ -4,3 +4,4 @@ set -e
 export DEFCONFIG=docker_rpi3_defconfig
 docker-compose build
 docker-compose run builder
+docker-compose down


### PR DESCRIPTION
- Added "docker-compose down" to cleanup the container and docker network after the build is done. Could also add the --rmi option, but that one is less cut and dried, because it means the image will have to be rebuilt again on subsequent builds
- Added pre-defined namespacing to docker resources so that the name is not dependent on the, sometimes badly named, parent directory
