### PR TITLE
Toolbelt and kernel version updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /opt/linaro && \
     curl -sSL https://releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu.tar.xz | tar xfJ - -C /opt/linaro
 ENV CROSS_COMPILE=/opt/linaro/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
 
-# Get the Linux kernel 4.14 source
+# Get the Linux kernel 4.19 source
 RUN git clone --single-branch --branch $RPI_KERNEL_BRANCH --depth 1 $RPI_KERNEL_REPO $LINUX
 
 COPY defconfigs/ /defconfigs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-FROM debian:jessie
+FROM debian:stretch
 
 WORKDIR /workdir
 ENV LINUX=/workdir/rpi64-linux \
     RPI_KERNEL_REPO=https://www.github.com/raspberrypi/linux \
-    RPI_KERNEL_BRANCH=rpi-4.14.y \
+    RPI_KERNEL_BRANCH=rpi-4.19.y \
     TIMESTAMP_OUTPUT=true
 
 # Install build dependencies
 RUN apt-get update && \
-  apt-get install -y bc build-essential curl git-core libncurses5-dev module-init-tools
+  apt-get install -y bc build-essential curl git-core libncurses5-dev kmod flex bison libssl-dev
 
 # Install crosscompile toolchain for ARM64/aarch64
 RUN mkdir -p /opt/linaro && \
-  curl -sSL http://releases.linaro.org/components/toolchain/binaries/7.1-2017.08/aarch64-linux-gnu/gcc-linaro-7.1.1-2017.08-x86_64_aarch64-linux-gnu.tar.xz | tar xfJ - -C /opt/linaro
-ENV CROSS_COMPILE=/opt/linaro/gcc-linaro-7.1.1-2017.08-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
+    curl -sSL https://releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu.tar.xz | tar xfJ - -C /opt/linaro
+ENV CROSS_COMPILE=/opt/linaro/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
 
 # Get the Linux kernel 4.14 source
 RUN git clone --single-branch --branch $RPI_KERNEL_BRANCH --depth 1 $RPI_KERNEL_REPO $LINUX


### PR DESCRIPTION
* RPI_KERNEL_BRANCH=rpi-4.19.y
* linaro/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu

NB: I didn't fiddle with any kernel configs. All compiles locally so far.